### PR TITLE
ci: run all tests and split evals into separate job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,11 +20,27 @@ jobs:
       - name: Install pytest
         run: pip install pytest
 
-      - name: Run validation tests
-        run: python3 -m pytest tests/test_validate.py -v
+      - name: Run tests
+        run: python3 -m pytest tests/ -v
+
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pytest
+        run: pip install pytest
 
       - name: Run evaluation suite
         run: python3 evals/run_evals.py
+
+      - name: Run evaluation tests
+        run: python3 -m pytest evals/tests/ -v
 
   prompt-regression:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- validate job now discovers all tests under tests/ instead of only test_validate.py (picks up test_build_sections.py)
- evals job runs run_evals.py plus pytest on evals/tests/ (5 test files that were previously uncovered)